### PR TITLE
Fix eslint for typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,11 @@ module.exports = {
     quotes: ["error", "double"],
     "import/no-extraneous-dependencies": ["error", { devDependencies: true }],
     "no-console": "off",
+    "max-len": ["error", { code: 300 }],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error",
     "import/extensions": [
       "error",
       "ignorePackages",


### PR DESCRIPTION
Eslint didn't seem to recognize some forms of typescript syntax. Apparently it needs to be explicitly told about it.